### PR TITLE
Implement interface and proxy features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,8 @@
 ## [Unreleased]
+
+### Added
+
+- Add `Solid::Adapters::Interface`
+- Add `Solid::Adapters::Proxy`
+- Add `Solid::Adapters::Configurable`
+- Add `Solid::Adapters.config`, `Solid::Adapters.configuration` (alias `.configure`) to toggle the gem's features.

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,6 @@ gem "standard", "~> 1.37"
 
 gem "minitest", "~> 5.24"
 
+gem "mocha", "~> 2.4", require: false
+
 gem "simplecov", "~> 0.22.0", require: false

--- a/lib/solid/adapters.rb
+++ b/lib/solid/adapters.rb
@@ -4,5 +4,25 @@ require_relative "adapters/version"
 
 module Solid
   module Adapters
+    module Core
+      require_relative "adapters/core/config"
+      require_relative "adapters/core/proxy"
+    end
+
+    require_relative "adapters/configurable"
+    require_relative "adapters/interface"
+    require_relative "adapters/proxy"
+
+    def self.config
+      Core::Config.instance
+    end
+
+    def self.configuration(freeze: true)
+      yield(config)
+
+      config.tap { _1.freeze if freeze }
+    end
+
+    singleton_class.send(:alias_method, :configure, :configuration)
   end
 end

--- a/lib/solid/adapters/configurable.rb
+++ b/lib/solid/adapters/configurable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Solid::Adapters
+  module Configurable
+    require_relative "configurable/options"
+
+    def config
+      @config ||= Options.new
+    end
+
+    def configuration(freeze: true)
+      yield(config)
+
+      config.tap { _1.freeze if freeze }
+    end
+
+    alias_method :configure, :configuration
+  end
+end

--- a/lib/solid/adapters/configurable/options.rb
+++ b/lib/solid/adapters/configurable/options.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Solid::Adapters::Configurable::Options
+  MapOption = ->(key) { key.end_with?("=") ? key[0..-2].to_sym : key }
+  MapValue = ->(value) { value.is_a?(::Proc) ? value.call : value }
+
+  def initialize(**options)
+    @options = options
+  end
+
+  def to_h
+    @options.dup
+  end
+
+  def key?(name)
+    @options.key?(name)
+  end
+
+  def [](name)
+    @options[name].then(&MapValue)
+  end
+
+  def fetch(name, &block)
+    @options.fetch(name, &block).then(&MapValue)
+  end
+
+  def method_missing(method_name, value = nil, &block)
+    return fetch(method_name) { super } if !method_name.end_with?("=") && !block
+
+    option_name = MapOption[method_name]
+
+    @options[option_name] = block || value
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    (method_name.end_with?("=") || key?(method_name)) || super
+  end
+
+  def freeze
+    @options.freeze
+
+    super
+  end
+end

--- a/lib/solid/adapters/core/config.rb
+++ b/lib/solid/adapters/core/config.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Solid::Adapters::Core
+  class Config
+    attr_accessor :proxy_enabled, :interface_enabled
+
+    def initialize(proxy_enabled: true, interface_enabled: true)
+      self.proxy_enabled = proxy_enabled
+      self.interface_enabled = interface_enabled
+    end
+
+    def proxy_enabled?
+      proxy_enabled
+    end
+
+    def interface_enabled?
+      interface_enabled
+    end
+
+    def options
+      {
+        proxy_enabled: proxy_enabled,
+        interface_enabled: interface_enabled
+      }
+    end
+
+    def inspect
+      "#<#{self.class.name} proxy_enabled=#{proxy_enabled}, interface_enabled=#{interface_enabled}>"
+    end
+
+    @instance = new
+
+    singleton_class.send(:attr_reader, :instance)
+  end
+end

--- a/lib/solid/adapters/core/proxy.rb
+++ b/lib/solid/adapters/core/proxy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Solid::Adapters::Core
+  module Proxy
+    module ClassMethods
+      def [](object)
+        new(object)
+      end
+
+      def to_proc
+        ->(object) { new(object) }
+      end
+    end
+
+    class Base
+      extend ClassMethods
+
+      attr_reader :object
+
+      def initialize(object)
+        @object = object
+      end
+    end
+  end
+end

--- a/lib/solid/adapters/interface.rb
+++ b/lib/solid/adapters/interface.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+module Solid::Adapters
+  module Interface
+    module Callbacks
+      def extended(impl)
+        impl.singleton_class.prepend(self::Methods)
+      end
+
+      def included(impl)
+        impl.prepend(self::Methods)
+      end
+    end
+
+    module ClassMethods
+      def [](object)
+        const_get(:Proxy, false).new(object).extend(self)
+      end
+    end
+
+    module ProxyDisabled
+      extend Core::Proxy::ClassMethods
+
+      def self.new(object)
+        object
+      end
+    end
+
+    DEFINE = lambda do |interface, enabled:|
+      proxy = ProxyDisabled
+
+      if enabled
+        proxy = ::Class.new(::SimpleDelegator)
+        proxy.extend(Core::Proxy::ClassMethods)
+
+        interface.extend(Callbacks)
+      end
+
+      interface.const_set(:Proxy, proxy)
+      interface.extend(ClassMethods)
+    end
+
+    def self.included(interface)
+      DEFINE[interface, enabled: Core::Config.instance.interface_enabled]
+    end
+
+    module AlwaysEnabled
+      def self.included(interface)
+        DEFINE[interface, enabled: true]
+      end
+    end
+
+    private_constant :Callbacks, :ClassMethods, :ProxyDisabled, :DEFINE
+  end
+end

--- a/lib/solid/adapters/proxy.rb
+++ b/lib/solid/adapters/proxy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Solid::Adapters
+  class Proxy < Core::Proxy::Base
+    AlwaysEnabled = ::Class.new(Core::Proxy::Base)
+
+    def self.new(object)
+      Core::Config.instance.proxy_enabled ? super : object
+    end
+  end
+end

--- a/test/solid/adapters/configurable_test.rb
+++ b/test/solid/adapters/configurable_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Solid::Adapters::ConfigurableTest < Minitest::Test
+  class Foo
+    extend Solid::Adapters::Configurable
+
+    NUMBERS = [1, 2, 3].freeze
+
+    config.bar = nil
+    config.biz = nil
+    config.number { NUMBERS.sample }
+  end
+
+  module Bar
+    extend Solid::Adapters::Configurable
+
+    config.foo = nil
+  end
+
+  test ".config" do
+    assert_nil Foo.config.bar
+
+    refute Foo.config.key?(:foo)
+    assert Foo.config.key?(:bar)
+
+    number = Foo.config.number
+
+    assert_includes Foo::NUMBERS, number
+
+    assert_equal([:bar, :biz, :number], Foo.config.to_h.keys.sort)
+    assert_nil(Foo.config.to_h[:bar])
+    assert_nil(Foo.config.to_h[:biz])
+    assert_kind_of(Proc, Foo.config.to_h[:number])
+
+    assert_raises(KeyError) { Foo.config.fetch(:foo) }
+    assert_equal "default", Foo.config.fetch(:foo) { "default" }
+
+    assert_nil Foo.config[:bar]
+
+    assert_nil Foo.config.fetch(:bar)
+    assert_nil(Foo.config.fetch(:bar) { "default" })
+
+    assert_nil Foo.config.bar
+    assert_nil Foo.config.biz
+
+    assert_respond_to Foo.config, :bar
+    assert_respond_to Foo.config, :bar=
+    assert_respond_to Foo.config, :biz
+    assert_respond_to Foo.config, :biz=
+
+    assert_respond_to Foo.config, :foo=
+    refute_respond_to Foo.config, :foo
+
+    Foo.config.bar = "BAR"
+
+    assert_equal "BAR", Foo.config.bar
+    assert_equal "BAR", Foo.config[:bar]
+    assert_equal "BAR", Foo.config.fetch(:bar)
+
+    assert_equal("BAR", Foo.config.to_h[:bar])
+    assert_nil(Foo.config.to_h[:biz])
+    assert_kind_of(Proc, Foo.config.to_h[:number])
+  end
+
+  test ".configuration(freeze: false)" do
+    Foo.configuration(freeze: false) do |config|
+      refute_predicate config, :frozen?
+
+      config.bar = "BAR"
+      config.biz = "BIZ"
+    end
+
+    assert_equal "BAR", Foo.config.bar
+    assert_equal "BIZ", Foo.config.biz
+
+    refute_predicate Foo.config, :frozen?
+  ensure
+    Foo.config.bar = nil
+    Foo.config.biz = nil
+  end
+
+  test ".configuration(freeze: true)" do
+    Bar.configuration(freeze: true) do |config|
+      refute_predicate config, :frozen?
+
+      config.foo = "FOO"
+    end
+
+    assert_equal "FOO", Bar.config.foo
+
+    assert_predicate Bar.config, :frozen?
+  end
+
+  test ".configure" do
+    assert_equal(Foo.method(:configure), Foo.method(:configuration))
+
+    assert_equal(Bar.method(:configure), Bar.method(:configuration))
+  end
+end

--- a/test/solid/adapters/core/proxy_test.rb
+++ b/test/solid/adapters/core/proxy_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Solid::Adapters
+  class CoreProxyTest < Minitest::Test
+    module Calc
+      class Contract < Core::Proxy::Base
+        FiniteNumber = lambda do |value|
+          value.is_a?(::Numeric) or raise format("%p must be numeric", value)
+          value.respond_to?(:finite?) && value.finite? or raise format("%p must be finite", value)
+          value
+        end
+
+        CannotBeZero = lambda do |value|
+          value.tap { _1.zero? and raise format("%p cannot be zero", _1) }
+        end
+
+        def add(a, b)
+          FiniteNumber[a]
+          FiniteNumber[b]
+
+          FiniteNumber[object.add(a, b)]
+        end
+
+        def subtract(a, b)
+          FiniteNumber[a]
+          FiniteNumber[b]
+
+          FiniteNumber[object.subtract(a, b)]
+        end
+
+        def divide(a, b)
+          FiniteNumber[a]
+          FiniteNumber[b].then(&CannotBeZero)
+
+          FiniteNumber[object.divide(a, b)]
+        end
+      end
+
+      class Operations
+        def initialize(calc)
+          @calc = Contract.new(calc)
+        end
+
+        def add(...)
+          @calc.add(...)
+        end
+
+        def subtract(...)
+          @calc.subtract(...)
+        end
+
+        def divide(...)
+          @calc.divide(...)
+        end
+      end
+    end
+
+    module NamespaceA
+      class CalcOperations
+        def add(a, b)
+          a + b
+        end
+
+        def subtract(a, b)
+          a - b
+        end
+
+        def divide(a, b)
+          a / b
+        end
+      end
+    end
+
+    module NamespaceB
+      module CalcOperations
+        def self.add(a, b)
+          a + b
+        end
+
+        def self.subtract(a, b)
+          a - b
+        end
+
+        def self.divide(a, b)
+          a / b
+        end
+      end
+    end
+
+    test "dependency inversion" do
+      calc1 = Calc::Operations.new(NamespaceA::CalcOperations.new)
+      calc2 = Calc::Operations.new(NamespaceB::CalcOperations)
+
+      assert_equal 3, calc1.add(1, 2)
+      assert_equal 3, calc2.add(1, 2)
+
+      assert_equal(-1, calc1.subtract(1, 2))
+      assert_equal(-1, calc2.subtract(1, 2))
+
+      assert_in_delta(0.5, calc1.divide(1.0, 2))
+      assert_in_delta(0.5, calc2.divide(1.0, 2))
+    end
+
+    test "contract errors" do
+      calc1 = Calc::Operations.new(NamespaceA::CalcOperations.new)
+      calc2 = Calc::Operations.new(NamespaceB::CalcOperations)
+
+      err1a = assert_raises(RuntimeError) { calc1.add(1, "2") }
+      err2a = assert_raises(RuntimeError) { calc1.subtract("1", 2) }
+      err3a = assert_raises(RuntimeError) { calc1.divide(1, 0) }
+
+      err1b = assert_raises(RuntimeError) { calc2.add("1", 2) }
+      err2b = assert_raises(RuntimeError) { calc2.subtract(1, "2") }
+      err3b = assert_raises(RuntimeError) { calc2.divide("1", 0) }
+
+      assert_equal('"2" must be numeric', err1a.message)
+      assert_equal('"1" must be numeric', err2a.message)
+      assert_equal("0 cannot be zero", err3a.message)
+
+      assert_equal('"1" must be numeric', err1b.message)
+      assert_equal('"2" must be numeric', err2b.message)
+      assert_equal('"1" must be numeric', err3b.message)
+    end
+
+    test ".new" do
+      object = ::Object.new
+
+      instance = Core::Proxy::Base.new(object)
+
+      assert_instance_of Core::Proxy::Base, instance
+    end
+
+    test ".new alias" do
+      object = ::Object.new
+
+      instance = Core::Proxy::Base[object]
+
+      assert_instance_of Core::Proxy::Base, instance
+    end
+
+    test ".to_proc" do
+      contracts = [NamespaceA::CalcOperations.new, NamespaceB::CalcOperations].map(&Calc::Contract)
+
+      assert_equal [Calc::Contract, Calc::Contract], contracts.map(&:class)
+
+      assert_equal 3, contracts[0].add(1, 2)
+      assert_equal 3, contracts[1].add(1, 2)
+    end
+
+    test "#object" do
+      object = ::Object.new
+
+      instance = Core::Proxy::Base.new(object)
+
+      assert_same object, instance.object
+    end
+  end
+end

--- a/test/solid/adapters/interface/config_test.rb
+++ b/test/solid/adapters/interface/config_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Solid::Adapters::Interface
+  class ConfigTest < Minitest::Test
+    module Factory
+      TEMPLATE = <<~RUBY
+        include Solid::Adapters::Interface%s
+
+        module Methods
+          def add(a, b)
+            a.is_a?(Integer) && b.is_a?(Integer) or raise("a and b must be integers")
+
+            super
+          end
+        end
+      RUBY
+
+      def self.interface(always_enabled: false)
+        compiled = format(TEMPLATE, always_enabled ? "::AlwaysEnabled" : "")
+
+        Module.new.tap { _1.module_eval(compiled) }
+      end
+    end
+
+    module Add
+      def add(a, b)
+        a + b
+      end
+    end
+
+    module Adder
+      extend Add
+    end
+
+    test "interface config (proxy side effect)" do
+      assert ::Solid::Adapters.config.interface_enabled
+      assert ::Solid::Adapters.config.interface_enabled?
+      assert ::Solid::Adapters.config.options[:interface_enabled]
+
+      interface1 = Factory.interface
+      interface2 = Factory.interface(always_enabled: true)
+
+      refute_same Adder, interface1[Adder]
+      refute_same Adder, interface2[Adder]
+
+      ins1 = Class.new { include(interface1, Add) }.new
+      mod1 = Module.new { extend(interface1, Add) }
+
+      ins2 = Class.new { include(interface2, Add) }.new
+      mod2 = Module.new { extend(interface2, Add) }
+
+      assert_raises(RuntimeError) { ins1.add("1", "1") }
+      assert_raises(RuntimeError) { mod1.add("1", "1") }
+
+      assert_raises(RuntimeError) { ins2.add("1", "1") }
+      assert_raises(RuntimeError) { mod2.add("1", "1") }
+
+      assert_equal 2, ins1.add(1, 1)
+      assert_equal 2, mod1.add(1, 1)
+
+      assert_equal 2, ins2.add(1, 1)
+      assert_equal 2, mod2.add(1, 1)
+
+      ::Solid::Adapters.config.interface_enabled = false
+
+      refute ::Solid::Adapters.config.interface_enabled
+      refute ::Solid::Adapters.config.interface_enabled?
+      refute ::Solid::Adapters.config.options[:interface_enabled]
+
+      interface3 = Factory.interface
+      interface4 = Factory.interface(always_enabled: true)
+
+      assert_same Adder, interface3[Adder]
+      refute_same Adder, interface4[Adder]
+
+      ins3 = Class.new { include(interface3, Add) }.new
+      mod3 = Module.new { extend(interface3, Add) }
+
+      ins4 = Class.new { include(interface4, Add) }.new
+      mod4 = Module.new { extend(interface4, Add) }
+
+      assert_equal "22", ins3.add("2", "2")
+      assert_equal "22", mod3.add("2", "2")
+
+      assert_raises(RuntimeError) { ins4.add("2", "2") }
+      assert_raises(RuntimeError) { mod4.add("2", "2") }
+
+      assert_equal 4, ins3.add(2, 2)
+      assert_equal 4, mod3.add(2, 2)
+
+      assert_equal 4, ins4.add(2, 2)
+      assert_equal 4, mod4.add(2, 2)
+    ensure
+      ::Solid::Adapters.config.interface_enabled = true
+
+      assert ::Solid::Adapters.config.interface_enabled
+      assert ::Solid::Adapters.config.interface_enabled?
+      assert ::Solid::Adapters.config.options[:interface_enabled]
+
+      interface5 = Factory.interface
+      interface6 = Factory.interface(always_enabled: true)
+
+      refute_same Adder, interface5[Adder]
+      refute_same Adder, interface6[Adder]
+
+      ins5 = Class.new { include(interface5, Add) }.new
+      mod5 = Module.new { extend(interface5, Add) }
+
+      ins6 = Class.new { include(interface6, Add) }.new
+      mod6 = Module.new { extend(interface6, Add) }
+
+      assert_raises(RuntimeError) { ins5.add("3", "3") }
+      assert_raises(RuntimeError) { mod5.add("3", "3") }
+
+      assert_raises(RuntimeError) { ins6.add("3", "3") }
+      assert_raises(RuntimeError) { mod6.add("3", "3") }
+
+      assert_equal 6, ins5.add(3, 3)
+      assert_equal 6, mod5.add(3, 3)
+
+      assert_equal 6, ins6.add(3, 3)
+      assert_equal 6, mod6.add(3, 3)
+    end
+  end
+end

--- a/test/solid/adapters/interface/proxy_test.rb
+++ b/test/solid/adapters/interface/proxy_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Solid::Adapters
+  class InterfaceProxyTest < Minitest::Test
+    module CalcInterface
+      include Solid::Adapters::Interface
+
+      module Methods
+        def add(a, b)
+          a.is_a?(Float) && b.is_a?(Float) or raise "a and b must be floats"
+
+          super.tap { _1.finite? or raise format("%p must be a finite float", _1) }
+        end
+      end
+    end
+
+    module CalcInterfaceAlwaysEnabled
+      include Solid::Adapters::Interface::AlwaysEnabled
+
+      module Methods
+        def add(a, b)
+          a.is_a?(Float) && b.is_a?(Float) or raise "a and b must be floats"
+
+          super.tap { _1.finite? or raise format("%p must be a finite float", _1) }
+        end
+      end
+    end
+
+    class Calc
+      def add(a, b)
+        a + b
+      end
+    end
+
+    module CalcMod
+      def self.add(a, b)
+        a + b
+      end
+    end
+
+    test "inteface proxy" do
+      refute_kind_of(CalcInterface, Calc.new)
+      refute_kind_of(CalcInterface, CalcMod)
+
+      refute_kind_of(CalcInterfaceAlwaysEnabled, Calc.new)
+      refute_kind_of(CalcInterfaceAlwaysEnabled, CalcMod)
+
+      calc1 = CalcInterface[Calc.new]
+      calc_mod1 = CalcInterface[CalcMod]
+
+      calc2 = CalcInterfaceAlwaysEnabled[Calc.new]
+      calc_mod2 = CalcInterfaceAlwaysEnabled[CalcMod]
+
+      assert_kind_of(CalcInterface, calc1)
+      assert_kind_of(CalcInterface, calc_mod1)
+
+      assert_kind_of(CalcInterfaceAlwaysEnabled, calc2)
+      assert_kind_of(CalcInterfaceAlwaysEnabled, calc_mod2)
+
+      assert_raises(RuntimeError, "a and b must be floats") { calc1.add(1, 2.0) }
+      assert_raises(RuntimeError, "a and b must be floats") { calc_mod1.add(1.0, 2) }
+      assert_raises(RuntimeError, "a and b must be floats") { calc2.add(1, 2.0) }
+      assert_raises(RuntimeError, "a and b must be floats") { calc_mod2.add(1.0, 2) }
+
+      assert_raises(RuntimeError, "NaN must be a finite float") { calc1.add(Float::NAN, 2.0) }
+      assert_raises(RuntimeError, "Infinity and b must be floats") { calc_mod1.add(1.0, Float::INFINITY) }
+      assert_raises(RuntimeError, "Infinity must be a finite float") { calc2.add(Float::INFINITY, 2.0) }
+      assert_raises(RuntimeError, "NaN must be a finite float") { calc_mod2.add(1.0, Float::NAN) }
+
+      assert_in_delta 3.0, calc1.add(1.0, 2.0)
+      assert_in_delta 3.0, calc_mod1.add(1.0, 2.0)
+      assert_in_delta 3.0, calc2.add(1.0, 2.0)
+      assert_in_delta 3.0, calc_mod2.add(1.0, 2.0)
+    end
+
+    test "that has the core proxy class methods" do
+      assert_kind_of Core::Proxy::ClassMethods, CalcInterface::Proxy
+
+      assert_kind_of Core::Proxy::ClassMethods, CalcInterfaceAlwaysEnabled::Proxy
+    end
+  end
+end

--- a/test/solid/adapters/interface_test.rb
+++ b/test/solid/adapters/interface_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Solid::Adapters::InterfaceTest < Minitest::Test
+  module CalcInterface
+    include Solid::Adapters::Interface
+
+    module Methods
+      def add(a, b)
+        a.is_a?(Float) && b.is_a?(Float) or raise "a and b must be floats"
+
+        super.tap { _1.finite? or raise format("%p must be a finite float", _1) }
+      end
+    end
+  end
+
+  module CalcInterfaceAlwaysEnabled
+    include Solid::Adapters::Interface::AlwaysEnabled
+
+    module Methods
+      def add(a, b)
+        a.is_a?(Float) && b.is_a?(Float) or raise "a and b must be floats"
+
+        super.tap { _1.finite? or raise format("%p must be a finite float", _1) }
+      end
+    end
+  end
+
+  module Calc
+    module Add
+      def add(a, b)
+        a + b
+      end
+    end
+
+    class Base
+      include Add
+    end
+  end
+
+  class Calc1a < Calc::Base
+    include CalcInterface
+  end
+
+  module Calc1b
+    extend CalcInterface
+
+    def self.add(a, b)
+      a + b
+    end
+  end
+
+  class Calc2a
+    include CalcInterfaceAlwaysEnabled
+
+    def add(a, b)
+      a + b
+    end
+  end
+
+  module Calc2b
+    extend CalcInterfaceAlwaysEnabled
+    extend Calc::Add
+  end
+
+  module Calc2c
+    extend Calc::Add
+    extend CalcInterfaceAlwaysEnabled
+  end
+
+  test "interfaces" do
+    assert_kind_of(CalcInterface, Calc1a.new)
+    assert_kind_of(CalcInterface, Calc1b)
+
+    assert_kind_of(CalcInterfaceAlwaysEnabled, Calc2a.new)
+    assert_kind_of(CalcInterfaceAlwaysEnabled, Calc2b)
+    assert_kind_of(CalcInterfaceAlwaysEnabled, Calc2c)
+
+    assert_raises(RuntimeError, "a and b must be floats") { Calc1a.new.add(1, 2.0) }
+    assert_raises(RuntimeError, "a and b must be floats") { Calc1b.add(1.0, 2) }
+    assert_raises(RuntimeError, "a and b must be floats") { Calc2a.new.add(1, 2.0) }
+    assert_raises(RuntimeError, "a and b must be floats") { Calc2b.add(1.0, 2) }
+    assert_raises(RuntimeError, "a and b must be floats") { Calc2c.add(1.0, 2) }
+
+    assert_raises(RuntimeError, "NaN must be a finite float") { Calc1a.new.add(Float::NAN, 2.0) }
+    assert_raises(RuntimeError, "Infinity and b must be floats") { Calc1b.add(1.0, Float::INFINITY) }
+    assert_raises(RuntimeError, "Infinity must be a finite float") { Calc2a.new.add(Float::INFINITY, 2.0) }
+    assert_raises(RuntimeError, "NaN must be a finite float") { Calc2b.add(1.0, Float::NAN) }
+    assert_raises(RuntimeError, "NaN must be a finite float") { Calc2c.add(Float::INFINITY, Float::NAN) }
+
+    assert_in_delta 3.0, Calc1a.new.add(1.0, 2.0)
+    assert_in_delta 3.0, Calc1b.add(1.0, 2.0)
+    assert_in_delta 3.0, Calc2a.new.add(1.0, 2.0)
+    assert_in_delta 3.0, Calc2b.add(1.0, 2.0)
+    assert_in_delta 3.0, Calc2c.add(1.0, 2.0)
+  end
+end

--- a/test/solid/adapters/proxy/config_test.rb
+++ b/test/solid/adapters/proxy/config_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Solid::Adapters::Proxy::ConfigTest < Minitest::Test
+  class ToggleableProxy < Solid::Adapters::Proxy
+    def add(a, b)
+      a.is_a?(Integer) && b.is_a?(Integer) or raise("a and b must be integers")
+
+      object.add(a, b)
+    end
+  end
+
+  class ProxyAlwaysEnabled < Solid::Adapters::Proxy::AlwaysEnabled
+    def add(a, b)
+      a.is_a?(Integer) && b.is_a?(Integer) or raise("a and b must be integers")
+
+      object.add(a, b)
+    end
+  end
+
+  module Adder
+    def self.add(a, b)
+      a + b
+    end
+  end
+
+  test "proxy config" do
+    assert Solid::Adapters.config.proxy_enabled
+    assert Solid::Adapters.config.proxy_enabled?
+    assert Solid::Adapters.config.options[:proxy_enabled]
+
+    assert_raises(RuntimeError) { ToggleableProxy[Adder].add("1", "1") }
+    assert_raises(RuntimeError) { ProxyAlwaysEnabled[Adder].add("1", "1") }
+
+    assert_equal 2, ToggleableProxy[Adder].add(1, 1)
+    assert_equal 2, ProxyAlwaysEnabled[Adder].add(1, 1)
+
+    Solid::Adapters.config.proxy_enabled = false
+
+    refute Solid::Adapters.config.proxy_enabled?
+    refute Solid::Adapters.config.proxy_enabled
+    refute Solid::Adapters.config.options[:proxy_enabled]
+
+    assert_equal "12", ToggleableProxy[Adder].add("1", "2")
+    assert_raises(RuntimeError) { ProxyAlwaysEnabled[Adder].add("1", "2") }
+
+    assert_equal 4, ToggleableProxy[Adder].add(2, 2)
+    assert_equal 4, ProxyAlwaysEnabled[Adder].add(2, 2)
+  ensure
+    Solid::Adapters.config.proxy_enabled = true
+
+    assert Solid::Adapters.config.proxy_enabled
+    assert Solid::Adapters.config.proxy_enabled?
+    assert Solid::Adapters.config.options[:proxy_enabled]
+
+    assert_raises(RuntimeError) { ToggleableProxy[Adder].add("1", "2") }
+    assert_raises(RuntimeError) { ProxyAlwaysEnabled[Adder].add("1", "2") }
+
+    assert_equal 6, ToggleableProxy[Adder].add(3, 3)
+    assert_equal 6, ProxyAlwaysEnabled[Adder].add(3, 3)
+  end
+end

--- a/test/solid/adapters/proxy_test.rb
+++ b/test/solid/adapters/proxy_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Solid::Adapters
+  class ProxyTest < Minitest::Test
+    test "the Proxy ancestor" do
+      assert_operator Proxy, :<, Core::Proxy::Base
+
+      refute_operator Proxy, :<, Proxy::AlwaysEnabled
+    end
+
+    test "the Proxy::AlwaysEnabled ancestor" do
+      assert_operator Proxy::AlwaysEnabled, :<, Core::Proxy::Base
+
+      refute_operator Proxy::AlwaysEnabled, :<, Proxy
+    end
+  end
+end

--- a/test/solid/adapters_test.rb
+++ b/test/solid/adapters_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Solid::AdaptersTest < Minitest::Test
+  test ".config" do
+    assert_same(Solid::Adapters::Core::Config.instance, Solid::Adapters.config)
+
+    assert(Solid::Adapters.config.proxy_enabled)
+    assert(Solid::Adapters.config.interface_enabled)
+
+    assert_predicate(Solid::Adapters.config, :proxy_enabled?)
+    assert_predicate(Solid::Adapters.config, :interface_enabled?)
+
+    assert_equal({proxy_enabled: true, interface_enabled: true}, Solid::Adapters.config.options)
+    assert_equal(
+      "#<Solid::Adapters::Core::Config proxy_enabled=true, interface_enabled=true>",
+      Solid::Adapters.config.inspect
+    )
+  end
+
+  test ".configure" do
+    assert_equal(Solid::Adapters.method(:configuration), Solid::Adapters.method(:configure))
+  end
+
+  test ".configuration(freeze: false)" do
+    Solid::Adapters.configuration(freeze: false) do |config|
+      assert_same(Solid::Adapters::Core::Config.instance, config)
+
+      refute_predicate(config, :frozen?)
+      assert_predicate(config, :proxy_enabled?)
+      assert_predicate(config, :interface_enabled?)
+    end
+  end
+
+  test ".configuration(freeze: true)" do
+    config_instance = Solid::Adapters::Core::Config.new
+
+    Solid::Adapters::Core::Config.expects(:instance).returns(config_instance).twice
+
+    Solid::Adapters.configuration(freeze: true) do |config|
+      assert_same(config_instance, config)
+
+      refute_predicate(config, :frozen?)
+      assert_predicate(config, :proxy_enabled?)
+      assert_predicate(config, :interface_enabled?)
+    end
+
+    assert_predicate(config_instance, :frozen?)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,9 +9,17 @@ SimpleCov.start do
 end
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
 require "solid/adapters"
 
+Dir[File.expand_path("support/**/*.rb", __dir__)]
+  .sort
+  .reject { |file| file.match?((RUBY_VERSION >= "3.0.0") ? /2_7/ : /gte_3/) }
+  .each { |file| require file }
+
 require "minitest/autorun"
+
+require "mocha/minitest"
 
 class Minitest::Test
   # Implementation based on:


### PR DESCRIPTION
### Added

- Add `Solid::Adapters::Interface`
- Add `Solid::Adapters::Proxy`
- Add `Solid::Adapters::Configurable`
- Add `Solid::Adapters.config`, `Solid::Adapters.configuration` (alias `.configure`) to toggle the gem's features.